### PR TITLE
pyglet expects int not float

### DIFF
--- a/moderngl_window/context/pyglet/window.py
+++ b/moderngl_window/context/pyglet/window.py
@@ -38,7 +38,7 @@ class Window(BaseWindow):
             self._width, self._height = screen.width, screen.height
 
         self._window = PygletWrapper(
-            width=self.width, height=self.height,
+            width=int(self.width), height=int(self.height),
             caption=self.title,
             resizable=self.resizable,
             vsync=self.vsync,


### PR DESCRIPTION
On windows to get the examples running I had to patch this line. I was not able to track down where gets the `width` and `height` the `float` type.

Please do not merge this if you know where the width and height get their value.
